### PR TITLE
Phase 3: 補單元測試（xUnit + NSubstitute）

### DIFF
--- a/TWStockLib.slnx
+++ b/TWStockLib.slnx
@@ -6,4 +6,8 @@
   <Folder Name="/samples/">
     <Project Path="TestExample/TestExample.csproj" />
   </Folder>
+  <Folder Name="/tests/">
+    <Project Path="tests/TWStockLib.Core.Tests/TWStockLib.Core.Tests.csproj" />
+    <Project Path="tests/TWStockLib.Twse.Tests/TWStockLib.Twse.Tests.csproj" />
+  </Folder>
 </Solution>

--- a/tests/TWStockLib.Core.Tests/GlobalUsings.cs
+++ b/tests/TWStockLib.Core.Tests/GlobalUsings.cs
@@ -1,0 +1,6 @@
+global using Xunit;
+global using NSubstitute;
+global using TWStockLib.Abstractions;
+global using TWStockLib.Models;
+global using TWStockLib.Observer;
+global using TWStockLib.Services;

--- a/tests/TWStockLib.Core.Tests/StockMarketServiceTests.cs
+++ b/tests/TWStockLib.Core.Tests/StockMarketServiceTests.cs
@@ -1,0 +1,109 @@
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace TWStockLib.Core.Tests;
+
+public class StockMarketServiceTests
+{
+    private static IStockDataSource FakeSource(MarketType market)
+    {
+        var source = Substitute.For<IStockDataSource>();
+        source.Market.Returns(market);
+        return source;
+    }
+
+    private static StockMarketService BuildService(params IStockDataSource[] sources)
+        => new(sources, NullLogger<StockMarketService>.Instance);
+
+    // ── 路由 ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetRealtimeQuoteAsync_UnknownMarket_ReturnsSourceNotFound()
+    {
+        var service = BuildService(FakeSource(MarketType.TSE));
+
+        var result = await service.GetRealtimeQuoteAsync("2330", MarketType.OTC);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(StockErrorCodes.SourceNotFound, result.ErrorCode);
+    }
+
+    [Fact]
+    public async Task GetRealtimeQuoteAsync_RoutesToMatchingMarket()
+    {
+        var tse = FakeSource(MarketType.TSE);
+        var otc = FakeSource(MarketType.OTC);
+        var quote = new StockQuote { Symbol = "2330", Name = "台積電", Market = MarketType.TSE, LastPrice = 1000m };
+        tse.FetchRealtimeQuoteAsync("2330", Arg.Any<CancellationToken>()).Returns(quote);
+
+        var result = await BuildService(tse, otc).GetRealtimeQuoteAsync("2330", MarketType.TSE);
+
+        Assert.True(result.IsSuccess);
+        Assert.Same(quote, result.Value);
+        await otc.DidNotReceive().FetchRealtimeQuoteAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    // ── 成功 / 失敗收斂 ───────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetRealtimeQuoteAsync_SourceReturnsNull_ReturnsNotFound()
+    {
+        var tse = FakeSource(MarketType.TSE);
+        tse.FetchRealtimeQuoteAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+           .Returns((StockQuote?)null);
+
+        var result = await BuildService(tse).GetRealtimeQuoteAsync("9999", MarketType.TSE);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(StockErrorCodes.NotFound, result.ErrorCode);
+    }
+
+    [Fact]
+    public async Task GetRealtimeQuoteAsync_SourceThrows_ReturnsUpstreamError()
+    {
+        var tse = FakeSource(MarketType.TSE);
+        tse.FetchRealtimeQuoteAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+           .Returns<StockQuote?>(_ => throw new HttpRequestException("boom"));
+
+        var result = await BuildService(tse).GetRealtimeQuoteAsync("2330", MarketType.TSE);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(StockErrorCodes.UpstreamError, result.ErrorCode);
+        Assert.Contains("boom", result.ErrorMessage);
+    }
+
+    // ── GetAllStockList 合併 ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetAllStockListAsync_MergesAllSources()
+    {
+        var tse = FakeSource(MarketType.TSE);
+        var otc = FakeSource(MarketType.OTC);
+        tse.FetchStockListAsync(Arg.Any<bool>(), Arg.Any<CancellationToken>())
+           .Returns(new Dictionary<string, StockData>
+           {
+               ["2330"] = new() { Symbol = "2330", Name = "台積電", Market = MarketType.TSE },
+           });
+        otc.FetchStockListAsync(Arg.Any<bool>(), Arg.Any<CancellationToken>())
+           .Returns(new Dictionary<string, StockData>
+           {
+               ["6510"] = new() { Symbol = "6510", Name = "精測", Market = MarketType.OTC },
+           });
+
+        var result = await BuildService(tse, otc).GetAllStockListAsync();
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(2, result.Value!.Count);
+        Assert.Contains("2330", result.Value.Keys);
+        Assert.Contains("6510", result.Value.Keys);
+    }
+
+    [Fact]
+    public async Task GetStockListAsync_UnknownMarket_ReturnsSourceNotFound()
+    {
+        var result = await BuildService(FakeSource(MarketType.TSE))
+            .GetStockListAsync(MarketType.OTC);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(StockErrorCodes.SourceNotFound, result.ErrorCode);
+    }
+}

--- a/tests/TWStockLib.Core.Tests/StockPriceSubjectTests.cs
+++ b/tests/TWStockLib.Core.Tests/StockPriceSubjectTests.cs
@@ -1,0 +1,88 @@
+namespace TWStockLib.Core.Tests;
+
+public class StockPriceSubjectTests
+{
+    private sealed class RecordingObserver : IStockPriceObserver
+    {
+        public readonly List<(decimal NewPrice, decimal OldPrice)> Changes = [];
+        public void OnPriceChanged(string symbol, decimal newPrice, decimal oldPrice)
+            => Changes.Add((newPrice, oldPrice));
+    }
+
+    [Fact]
+    public void UpdatePrice_FirstUpdate_DoesNotNotify()
+    {
+        var subject = new StockPriceSubject();
+        var observer = new RecordingObserver();
+        subject.Subscribe("2330", observer);
+
+        subject.UpdatePrice("2330", 100m);
+
+        Assert.Empty(observer.Changes);
+    }
+
+    [Fact]
+    public void UpdatePrice_PriceChanged_NotifiesWithOldAndNew()
+    {
+        var subject = new StockPriceSubject();
+        var observer = new RecordingObserver();
+        subject.Subscribe("2330", observer);
+
+        subject.UpdatePrice("2330", 100m);
+        subject.UpdatePrice("2330", 105m);
+
+        var change = Assert.Single(observer.Changes);
+        Assert.Equal(105m, change.NewPrice);
+        Assert.Equal(100m, change.OldPrice);
+    }
+
+    [Fact]
+    public void UpdatePrice_SamePrice_DoesNotNotify()
+    {
+        var subject = new StockPriceSubject();
+        var observer = new RecordingObserver();
+        subject.Subscribe("2330", observer);
+
+        subject.UpdatePrice("2330", 100m);
+        subject.UpdatePrice("2330", 100m);
+
+        Assert.Empty(observer.Changes);
+    }
+
+    [Fact]
+    public void Unsubscribe_StopsNotifications()
+    {
+        var subject = new StockPriceSubject();
+        var observer = new RecordingObserver();
+        subject.Subscribe("2330", observer);
+        subject.UpdatePrice("2330", 100m);
+
+        subject.Unsubscribe("2330", observer);
+        subject.UpdatePrice("2330", 110m);
+
+        Assert.Empty(observer.Changes);
+    }
+}
+
+public class StockResultTests
+{
+    [Fact]
+    public void Ok_CarriesValue_AndIsSuccess()
+    {
+        var result = StockResult<int>.Ok(42);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(42, result.Value);
+        Assert.Null(result.ErrorCode);
+    }
+
+    [Fact]
+    public void Fail_CarriesCodeAndMessage()
+    {
+        var result = StockResult<int>.Fail("CODE", "message");
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("CODE", result.ErrorCode);
+        Assert.Equal("message", result.ErrorMessage);
+    }
+}

--- a/tests/TWStockLib.Core.Tests/TWStockLib.Core.Tests.csproj
+++ b/tests/TWStockLib.Core.Tests/TWStockLib.Core.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="NSubstitute" Version="5.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\TWStockLib.Core\TWStockLib.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/TWStockLib.Twse.Tests/GlobalUsings.cs
+++ b/tests/TWStockLib.Twse.Tests/GlobalUsings.cs
@@ -1,0 +1,3 @@
+global using Xunit;
+global using TWStockLib.Models;
+global using TWStockLib.Twse.Parsers;

--- a/tests/TWStockLib.Twse.Tests/TWStockLib.Twse.Tests.csproj
+++ b/tests/TWStockLib.Twse.Tests/TWStockLib.Twse.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\TWStockLib.Twse\TWStockLib.Twse.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/TWStockLib.Twse.Tests/TwseStockParserTests.cs
+++ b/tests/TWStockLib.Twse.Tests/TwseStockParserTests.cs
@@ -1,0 +1,135 @@
+namespace TWStockLib.Twse.Tests;
+
+public class TwseStockParserTests
+{
+    private readonly TwseStockParser _parser = new();
+
+    // ── 即時報價 ──────────────────────────────────────────────────────────────
+
+    private const string QuoteJson = """
+    {"msgArray":[{
+        "c":"2330","n":"台積電",
+        "z":"600.00","tv":"5","v":"20000",
+        "a":"601.00_602.00","f":"10_20",
+        "b":"599.00_598.00","g":"30_40",
+        "o":"595.00","h":"605.00","l":"594.00",
+        "y":"596.00","u":"655.00","w":"537.00",
+        "tlong":"1699000000000"
+    }]}
+    """;
+
+    [Fact]
+    public void ParseRealtimeQuote_MapsAllFields()
+    {
+        var quote = _parser.ParseRealtimeQuote(QuoteJson, MarketType.TSE);
+
+        Assert.NotNull(quote);
+        Assert.Equal("2330", quote!.Symbol);
+        Assert.Equal("台積電", quote.Name);
+        Assert.Equal(MarketType.TSE, quote.Market);
+        Assert.Equal(600.00m, quote.LastPrice);
+        Assert.Equal(596.00m, quote.YesterdayClosingPrice);
+        Assert.Equal(new[] { 601.00m, 602.00m }, quote.Top5SellPrice);
+        Assert.Equal(new uint[] { 10, 20 }, quote.Top5SellVolume);
+        Assert.Equal(new[] { 599.00m, 598.00m }, quote.Top5BuyPrice);
+    }
+
+    [Fact]
+    public void ParseRealtimeQuote_EmptyMsgArray_ReturnsNull()
+    {
+        Assert.Null(_parser.ParseRealtimeQuote("""{"msgArray":[]}""", MarketType.TSE));
+    }
+
+    [Fact]
+    public void ParseRealtimeQuote_DashValues_BecomeNull()
+    {
+        var json = """{"msgArray":[{"c":"2330","n":"台積電","z":"-","o":"-"}]}""";
+
+        var quote = _parser.ParseRealtimeQuote(json, MarketType.TSE);
+
+        Assert.NotNull(quote);
+        Assert.Null(quote!.LastPrice);
+        Assert.Null(quote.OpeningPrice);
+    }
+
+    // ── TSE 歷史（STOCK_DAY）─────────────────────────────────────────────────
+
+    [Fact]
+    public void ParseTwseHistory_OkStat_ParsesRowsWithRocDate()
+    {
+        const string json = """
+        {"stat":"OK","data":[
+            ["108/11/01","1,000,000","30,000,000","30.00","31.00","29.50","30.50","+0.50","500"]
+        ]}
+        """;
+
+        var rows = _parser.ParseTwseHistory(json);
+
+        var row = Assert.Single(rows);
+        Assert.Equal(new DateTime(2019, 11, 1), row.Date); // 民國 108 → 西元 2019
+        Assert.Equal(1_000_000u, row.TradeVolume);
+        Assert.Equal(30.00m, row.OpeningPrice);
+        Assert.Equal(30.50m, row.ClosingPrice);
+        Assert.Equal(500u, row.NumberOfDeals);
+    }
+
+    [Fact]
+    public void ParseTwseHistory_NonOkStat_ReturnsEmpty()
+    {
+        Assert.Empty(_parser.ParseTwseHistory("""{"stat":"很抱歉，沒有符合條件的資料!"}"""));
+    }
+
+    // ── OTC 歷史（TPEX st43）─────────────────────────────────────────────────
+
+    [Fact]
+    public void ParseTpexHistory_ParsesFirstTableRows()
+    {
+        const string json = """
+        {"tables":[{"data":[
+            ["112/11/01","2,000","60,000","100.0","101.0","99.0","100.5","0.5","123"]
+        ]}]}
+        """;
+
+        var rows = _parser.ParseTpexHistory(json);
+
+        var row = Assert.Single(rows);
+        Assert.Equal(new DateTime(2023, 11, 1), row.Date);
+        Assert.Equal(2_000u, row.TradeVolume);
+        Assert.Equal(100.5m, row.ClosingPrice);
+    }
+
+    [Fact]
+    public void ParseTpexHistory_NoTables_ReturnsEmpty()
+    {
+        Assert.Empty(_parser.ParseTpexHistory("""{"tables":[]}"""));
+    }
+
+    // ── 股票清單（ISIN HTML）──────────────────────────────────────────────────
+
+    private const string IsinHtml = """
+    <html><body><table class="h4"><tbody>
+        <tr><td bgcolor="#FAFAD2">2330　台積電</td></tr>
+        <tr><td bgcolor="#FAFAD2">081234　大盤購01</td></tr>
+    </tbody></table></body></html>
+    """;
+
+    [Fact]
+    public void ParseStockList_ExcludesWarrants_ByDefault()
+    {
+        var list = _parser.ParseStockList(IsinHtml, MarketType.TSE, includeWarrant: false);
+
+        var entry = Assert.Single(list);
+        Assert.Equal("2330", entry.Key);
+        Assert.Equal("台積電", entry.Value.Name);
+        Assert.Equal(MarketType.TSE, entry.Value.Market);
+    }
+
+    [Fact]
+    public void ParseStockList_IncludesWarrants_WhenRequested()
+    {
+        var list = _parser.ParseStockList(IsinHtml, MarketType.TSE, includeWarrant: true);
+
+        Assert.Equal(2, list.Count);
+        Assert.Contains("081234", list.Keys);
+    }
+}


### PR DESCRIPTION
@
## 概要

重構計畫第四步(Phase 3):補上單元測試。Phase 2 把解析邏輯拆成純函式 `TwseStockParser` 後,現在能完全離線驗證——這正是該重構的最大價值兌現。測試框架對齊 `DataAnalysisLibrary`(xUnit / NSubstitute / coverlet)。

## 新增測試(21 個,全綠、不打網路)

### `tests/TWStockLib.Twse.Tests`(9 個)— `TwseStockParser` 純函式,餵內嵌 fixture
- 即時報價欄位映射、空 `msgArray` → null、`"-"` 值 → null
- TSE(STOCK_DAY)/ OTC(TPEX st43)歷史的**民國日期換算**(108→2019、112→2023)
- ISIN 股票清單的**權證過濾**(預設排除 / `includeWarrant` 納入)

### `tests/TWStockLib.Core.Tests`(12 個)
- `StockMarketService` 用假 `IStockDataSource` 測:市場路由、`SOURCE_NOT_FOUND` / `NOT_FOUND` / `UPSTREAM_ERROR` 收斂、`GetAllStockList` 合併、路由不誤呼其他來源
- `StockPriceSubject` 通知邏輯(首次不通知、變動才通知、同價不通知、取消後不通知)
- `StockResult` Ok / Fail

## 驗證

- `dotnet test TWStockLib.slnx -c Release` → **Core 12 + Twse 9 = 21 passed / 0 failed**
- `.slnx` 已納入兩個測試專案;CI 會自動跑

## 後續

Phase 4(收尾發佈):更新 README 對齊新 async / `StockResult` API、版本決策、設定 `NUGET_API_KEY`、打 tag 發佈。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@