### PR TITLE
Phase 4: 收尾發佈 — README 對齊新 API、版本升 2.0.0

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -70,7 +70,7 @@
 
 - [ ] 更新 `README.md`：對齊新 API（`AddTwStock`、`StockResult<T>`、async/ct），修掉 `CreatePriceObserver` 等不存在的範例。
 - [ ] `DESIGN.md` 連入 README（設計模式總表就是「高大尚」觀感來源）。
-- [ ] 版本號訂為 `1.1.0`（API 有破壞性變更，主版號可考慮 `2.0.0`）。
+- [x] 版本號訂為 `2.0.0`（API 有破壞性變更，依 SemVer 跳大版號）。
 - [ ] 設定 GitHub repo secret `NUGET_API_KEY`。
 - [ ] 打 tag `v1.1.0` → 確認 publish workflow 成功推上 NuGet（Core + Twse 兩個套件）。
 

--- a/README.md
+++ b/README.md
@@ -1,249 +1,171 @@
 # TWStockLib
 
-TWStockLib 是一個用於獲取台灣股市資料的 .NET 類別庫。它提供了獲取股票清單、歷史數據和即時報價的功能，並支援價格變化的觀察者模式。
+TWStockLib 是一個用於獲取台灣股市資料的 .NET 類別庫，提供股票清單、歷史數據與即時報價，並支援價格變化的觀察者模式。
+
+- 全非同步、可取消（`async` + `CancellationToken`）
+- 統一以 `StockResult<T>` 回傳成功 / 失敗，呼叫端免到處 try-catch
+- 每個市場一個資料來源，新增市場零修改現有程式碼（OCP）
+- 純函式解析層（與 IO 分離），可離線單元測試
+- 支援 `net8.0` / `net9.0`
+
+> 架構與設計模式說明見 [DESIGN.md](DESIGN.md)。
 
 ## 安裝
-
-通過 NuGet 安裝 TWStockLib：
 
 ```
 dotnet add package TWStockLib
 ```
 
-或在 Visual Studio 的 NuGet 套件管理器中搜尋 `TWStockLib`。
+`TWStockLib` 會自動帶入核心套件 `TWStockLib.Core`。若只需要核心抽象與模型（不含證交所來源實作），可單獨安裝：
 
+```
+dotnet add package TWStockLib.Core
+```
 
 ## 功能特點
 
-- 獲取上市（TSE）和上櫃（OTC）股票清單
-- 獲取股票歷史數據
+- 獲取上市（TSE）與上櫃（OTC）股票清單
+- 獲取股票歷史數據（跨月自動合併）
 - 獲取股票即時報價
 - 監控股票價格變化（觀察者模式）
-- 支援快取機制，減少 API 請求
-- 完整的錯誤處理和日誌記錄
+- 內建快取，減少對上游的請求
+- 完整的錯誤處理與日誌記錄
 
 ## 快速入門
 
-### 步驟 1: 註冊服務
-
-在 `Program.cs` 或 `Startup.cs` 中註冊 TWStockLib 服務：
+### 步驟 1：註冊服務
 
 ```csharp
-// 註冊編碼提供者，以支援 950 (繁體中文 Big5) 編碼
-Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
-
-// 添加 TWStockLib 服務
-services.AddStockServices();
-```
-
-### 步驟 2: 獲取 StockMarketService
-
-#### 在一般Console中使用：
-
-```csharp
-var stockMarketService = serviceProvider.GetRequiredService<StockMarketService>();
-```
-
-#### 在Controller中通過依賴注入使用：
-
-```csharp
+using Microsoft.Extensions.DependencyInjection;
 using TWStockLib.Services;
-using TWStockLib.Models;
 
-public class YourController : Controller
+var services = new ServiceCollection();
+services.AddLogging();
+services.AddTwStock();   // 註冊 TWStockLib 服務（含 TSE / OTC 兩個資料來源）
+
+var provider = services.BuildServiceProvider();
+```
+
+### 步驟 2：取得服務
+
+在 Console 中：
+
+```csharp
+var stock = provider.GetRequiredService<IStockMarketService>();
+```
+
+在 Controller 中透過建構式注入：
+
+```csharp
+public class StockController : Controller
 {
-    private readonly IStockMarketService _stockMarketService;
-
-    public YourController(IStockMarketService stockMarketService)
-    {
-        _stockMarketService = stockMarketService;
-    }
+    private readonly IStockMarketService _stock;
+    public StockController(IStockMarketService stock) => _stock = stock;
 }
 ```
 
-### 步驟 3: 使用服務功能
+### 步驟 3：使用服務
+
+所有查詢方法皆為非同步，並回傳 `StockResult<T>`：以 `IsSuccess` 判斷成功，失敗時帶 `ErrorCode` / `ErrorMessage`。
 
 #### 獲取股票清單
 
 ```csharp
-// 獲取所有股票
-var allStocks = await stockMarketService.GetAllStockList();
+var all = await stock.GetAllStockListAsync();
+if (all.IsSuccess)
+    Console.WriteLine($"共 {all.Value!.Count} 支股票");
 
-// 獲取上市股票
-var tseStocks = await stockMarketService.GetStockList(MarketType.TSE);
-
-// 獲取上櫃股票
-var otcStocks = await stockMarketService.GetStockList(MarketType.OTC);
+var tse = await stock.GetStockListAsync(MarketType.TSE);
+var otc = await stock.GetStockListAsync(MarketType.OTC);
 ```
 
 #### 獲取歷史數據
 
 ```csharp
-// 獲取上市股票歷史數據
-var tseHistory = await stockMarketService.GetHistoricalData(
-    "2330",                     // 股票代碼
-    new DateTime(2023, 1, 1),   // 開始日期
-    new DateTime(2023, 1, 31),  // 結束日期
-    MarketType.TSE              // 市場類型
-);
+var history = await stock.GetHistoricalDataAsync(
+    "2330",
+    new DateTime(2023, 1, 1),
+    new DateTime(2023, 1, 31),
+    MarketType.TSE);
 
-// 獲取上櫃股票歷史數據
-var otcHistory = await stockMarketService.GetHistoricalData(
-    "6510",                     // 股票代碼
-    new DateTime(2023, 1, 1),   // 開始日期
-    new DateTime(2023, 1, 31),  // 結束日期
-    MarketType.OTC              // 市場類型
-);
-
-// 使用歷史數據
-foreach (var record in tseHistory)
+if (history.IsSuccess)
 {
-    Console.WriteLine($"日期: {record.Date:yyyy-MM-dd}, 開盤: {record.OpeningPrice}, 收盤: {record.ClosingPrice}");
+    foreach (var d in history.Value!)
+        Console.WriteLine($"{d.Date:yyyy-MM-dd} 開:{d.OpeningPrice} 收:{d.ClosingPrice}");
 }
 ```
 
 #### 獲取即時報價
 
 ```csharp
-// 獲取上市股票即時報價
-var tseQuote = await stockMarketService.GetRealtimeQuote("2330", MarketType.TSE);
-
-// 獲取上櫃股票即時報價
-var otcQuote = await stockMarketService.GetRealtimeQuote("6510", MarketType.OTC);
-
-// 使用即時報價
-if (tseQuote != null)
+var result = await stock.GetRealtimeQuoteAsync("2330", MarketType.TSE);
+if (result.IsSuccess)
 {
-    Console.WriteLine($"股票: {tseQuote.Symbol} {tseQuote.Name}");
-    Console.WriteLine($"最新價格: {tseQuote.LastPrice}");
-    Console.WriteLine($"最高價: {tseQuote.HighestPrice}");
-    Console.WriteLine($"最低價: {tseQuote.LowestPrice}");
-    Console.WriteLine($"開盤價: {tseQuote.OpeningPrice}");
-    Console.WriteLine($"昨收價: {tseQuote.YesterdayClosingPrice}");
-    Console.WriteLine($"成交量: {tseQuote.TotalVolume}");
+    var q = result.Value!;
+    Console.WriteLine($"{q.Symbol} {q.Name} 最新價:{q.LastPrice} 最高:{q.HighestPrice} 最低:{q.LowestPrice}");
+}
+else
+{
+    Console.WriteLine($"取得失敗：{result.ErrorCode} - {result.ErrorMessage}");
 }
 ```
 
 #### 使用觀察者模式監控價格變化
 
 ```csharp
-// 創建觀察者
-public class MyPriceObserver : IStockPriceObserver
+using TWStockLib.Observer;
+
+public class MyObserver : IStockPriceObserver
 {
     public void OnPriceChanged(string symbol, decimal newPrice, decimal oldPrice)
     {
-        var changePercentage = (newPrice - oldPrice) / oldPrice * 100;
-        var direction = newPrice > oldPrice ? "上漲" : "下跌";
-        
-        Console.WriteLine($"股票 {symbol} {direction}: 從 {oldPrice} 到 {newPrice} ({changePercentage:F2}%)");
+        var pct = (newPrice - oldPrice) / oldPrice * 100;
+        Console.WriteLine($"{symbol} {(newPrice > oldPrice ? "上漲" : "下跌")}：{oldPrice} → {newPrice} ({pct:F2}%)");
     }
 }
 
-// 使用內建的觀察者
-var observer = stockMarketService.CreatePriceObserver("MyObserver");
+var observer = new MyObserver();
+stock.SubscribePriceChanges("2330", observer);
 
-// 或使用自定義觀察者
-var myObserver = new MyPriceObserver();
+// 連續取得報價時，價格變動會通知觀察者
+await stock.GetRealtimeQuoteAsync("2330", MarketType.TSE);
 
-// 訂閱價格變化
-stockMarketService.SubscribePriceChanges("2330", observer);
-
-// 獲取報價時會自動通知觀察者
-var quote = await stockMarketService.GetRealtimeQuote("2330", MarketType.TSE);
-
-// 取消訂閱
-stockMarketService.UnsubscribePriceChanges("2330", observer);
+stock.UnsubscribePriceChanges("2330", observer);
 ```
 
-## 完整範例
+> 內建 `ConsoleStockPriceObserver`（於 `TWStockLib.Observer.DefaultProvidedObservers`）可直接使用。
 
-```csharp
-using Microsoft.Extensions.DependencyInjection;
-using TWStockLib.Models;
-using TWStockLib.Observer;
-using TWStockLib.Services;
-using System;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+## 錯誤碼
 
-namespace StockLibExample
-{
-    class Program
-    {
-        static async Task Main(string[] args)
-        {
-            // 註冊編碼提供者，以支援 950 (繁體中文 Big5) 編碼
-            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
-            
-            // 設置服務
-            var services = new ServiceCollection();
-            services.AddStockServices();
-            var serviceProvider = services.BuildServiceProvider();
-            
-            // 獲取 StockMarketService
-            var stockMarketService = serviceProvider.GetRequiredService<StockMarketService>();
-            
-            // 創建觀察者
-            var observer = stockMarketService.CreatePriceObserver("MyObserver");
-            
-            try
-            {
-                // 獲取股票清單
-                Console.WriteLine("獲取股票清單...");
-                var allStocks = await stockMarketService.GetAllStockList();
-                Console.WriteLine($"總共獲取到 {allStocks.Count} 支股票");
-                
-                // 獲取歷史數據
-                Console.WriteLine("獲取歷史數據...");
-                var tseHistory = await stockMarketService.GetHistoricalData(
-                    "2330", 
-                    new DateTime(2023, 1, 1), 
-                    new DateTime(2023, 1, 31),
-                    MarketType.TSE);
-                
-                Console.WriteLine($"2330 歷史數據: {tseHistory.Count()} 筆");
-                
-                // 訂閱價格變化
-                stockMarketService.SubscribePriceChanges("2330", observer);
-                
-                // 獲取即時報價
-                Console.WriteLine("獲取即時報價...");
-                var quote = await stockMarketService.GetRealtimeQuote("2330", MarketType.TSE);
-                
-                if (quote != null)
-                {
-                    Console.WriteLine($"2330 {quote.Name} 目前價格: {quote.LastPrice}");
-                }
-                else
-                {
-                    Console.WriteLine("無法獲取 2330 的報價");
-                }
-                
-                // 取消訂閱
-                stockMarketService.UnsubscribePriceChanges("2330", observer);
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine($"發生錯誤: {ex.Message}");
-            }
-        }
-    }
-}
-```
+`StockResult<T>.ErrorCode` 可能的值（見 `StockErrorCodes`）：
 
-## 注意事項
-
-1. 所有資料來源都是從網路獲取，因此需要連接網路才能使用。
-2. 歷史數據的獲取是按月為單位，如果指定的日期範圍跨越多個月，會自動獲取所有相關月份的數據。
-3. 即時報價數據有 30 秒的快取時間，以避免過多的 API 請求。
-4. 股票清單數據有 1 天的快取時間。
+| 錯誤碼 | 意義 |
+|--------|------|
+| `SOURCE_NOT_FOUND` | 找不到對應市場的資料來源 |
+| `NOT_FOUND` | 上游查無此股票 / 無資料 |
+| `UPSTREAM_ERROR` | 上游連線或回應錯誤 |
 
 ## 支援的市場
 
-- TSE (台灣證券交易所，上市)
-- OTC (櫃買中心，上櫃)
+- TSE（台灣證券交易所，上市）
+- OTC（櫃買中心，上櫃）
+
+## 注意事項
+
+1. 所有資料皆從網路即時獲取，需要連線。
+2. 歷史數據以月為單位查詢，跨月會自動合併。
+3. 即時報價快取 30 秒、股票清單與歷史快取 1 天，以減少上游請求。
+
+## 從 1.0.x 升級
+
+2.0 版為架構重構，API 有破壞性變更：
+
+- `AddStockServices()` → `AddTwStock()`（舊名仍保留但標記 `[Obsolete]`）
+- 服務方法改為非同步並回傳 `StockResult<T>`：
+  `GetRealtimeQuote` → `GetRealtimeQuoteAsync`、`GetHistoricalData` → `GetHistoricalDataAsync`、
+  `GetStockList` → `GetStockListAsync`、`GetAllStockList` → `GetAllStockListAsync`
+- 以 `IStockMarketService` 介面注入（取代具體型別 `StockMarketService`）
 
 ## 授權
 
-本專案採用 MIT 授權。詳情請參閱 [LICENSE](LICENSE) 文件。
+本專案採用 MIT 授權，詳見 [LICENSE](LICENSE)。

--- a/src/TWStockLib.Core/TWStockLib.Core.csproj
+++ b/src/TWStockLib.Core/TWStockLib.Core.csproj
@@ -7,7 +7,7 @@
     <!-- 套件專屬資訊（共用部分見 ..\..\Directory.Build.props） -->
     <IsPackable>true</IsPackable>
     <PackageId>TWStockLib.Core</PackageId>
-    <Version>1.1.0</Version>
+    <Version>2.0.0</Version>
     <Description>TWStockLib 核心抽象與模型（無 TWSE 來源依賴）。</Description>
   </PropertyGroup>
 

--- a/src/TWStockLib.Twse/TWStockLib.Twse.csproj
+++ b/src/TWStockLib.Twse/TWStockLib.Twse.csproj
@@ -8,7 +8,7 @@
          照常可用，並自動帶入 TWStockLib.Core。組件名為 TWStockLib.Twse。 -->
     <IsPackable>true</IsPackable>
     <PackageId>TWStockLib</PackageId>
-    <Version>1.1.0</Version>
+    <Version>2.0.0</Version>
     <Description>台灣股票類別庫 — 證交所（TSE）/ 櫃買（OTC）資料來源實作。</Description>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>


### PR DESCRIPTION
@
## 概要

重構計畫最後一步(Phase 4):更新文件、訂版本號,為發佈 NuGet 做好準備。

## 變更內容

- **重寫 README** 對齊新架構:
  - async + `StockResult<T>` API、`AddTwStock()`、`IStockMarketService` 注入
  - 兩套件安裝說明(`TWStockLib` 自動帶入 `TWStockLib.Core`)
  - 錯誤碼表、`1.0.x → 2.0` 升級指引、連入 `DESIGN.md`
  - 移除舊同步範例與不存在的 `CreatePriceObserver`
- **版本 `1.1.0` → `2.0.0`**(API 破壞性變更,依 SemVer 跳大版號)
- `PLAN.md` 標記版本決策完成

## 驗證

- `dotnet test` → **21 passed / 0 failed**
- 本機 `dotnet pack` 兩套件 **2.0.0** 成功,含 symbols(snupkg)

## 發佈步驟(本 PR merge 後)

1. 於 nuget.org（帳號 `jacky19918`）建立 API Key（Glob `TWStockLib*`、Push 權限）
2. 設定 repo secret `NUGET_API_KEY`
3. 打 tag `v2.0.0` → `publish.yml` 自動 pack + push `TWStockLib` 與 `TWStockLib.Core`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@